### PR TITLE
Investigate newline character behavior

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -11,7 +11,7 @@ import FooterFour from "@/components/footerFour.js";
 import ScrollTop from "@/components/scrollTop.js";
 
 export default function PageAboutUs(){
-    const { t, isLoading } = useLanguage();
+    const { t, tWithLineBreaks, isLoading } = useLanguage();
     if (isLoading) return null;
 
     const aboutData = [
@@ -70,7 +70,7 @@ export default function PageAboutUs(){
                     <div className="col-lg-7 col-md-6 mt-4 pt-2 mt-sm-0 pt-sm-0">
                         <div className="section-title ms-lg-5">
                             <h4 className="title mb-3">{t('about.title')}</h4>
-                            <p className="text-muted">{t('about.intro')}</p>
+                            <p className="text-muted" style={{whiteSpace: 'pre-line'}}>{t('about.intro')}</p>
                             <ul className="list-unstyled text-muted mb-0">
                                 <li className="mb-0">
                                     <span className="text-dark h5 me-2">{t('about.vision.title')}</span>

--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -7,6 +7,7 @@ type LanguageContextType = {
   language: string;
   setLanguage: React.Dispatch<React.SetStateAction<string>>;
   t: (key: string) => string;
+  tWithLineBreaks: (key: string) => React.JSX.Element;
   isLoading: boolean;
   translations: RootTranslations;
 };
@@ -38,8 +39,23 @@ export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     }, translations as unknown) as string || key;
   };
 
+  // Helper function to render text with line breaks
+  const tWithLineBreaks = (key: string): React.JSX.Element => {
+    const text = t(key);
+    return (
+      <>
+        {text.split('\n').map((line, index) => (
+          <React.Fragment key={index}>
+            {line}
+            {index < text.split('\n').length - 1 && <br />}
+          </React.Fragment>
+        ))}
+      </>
+    );
+  };
+
   return (
-    <LanguageContext.Provider value={{ language, setLanguage, t, isLoading, translations }}>
+    <LanguageContext.Provider value={{ language, setLanguage, t, tWithLineBreaks, isLoading, translations }}>
       {children}
     </LanguageContext.Provider>
   );


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix `\n` characters not rendering as line breaks in translated text.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
HTML/JSX treats `\n` characters in strings as regular whitespace, preventing them from rendering as visible line breaks. This PR addresses the issue by applying `white-space: pre-line` to the relevant text element in `about/page.tsx` and by introducing a `tWithLineBreaks` helper function in `LanguageContext.tsx` as an alternative for more programmatic control over line break rendering.

---
<a href="https://cursor.com/background-agent?bcId=bc-893b7ada-d304-4513-adb3-d5660def5e36">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-893b7ada-d304-4513-adb3-d5660def5e36">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>